### PR TITLE
usb: move USB interface related classes to a new 'usb' package

### DIFF
--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/CellularDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/CellularDevice.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/DigiMeshDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/DigiMeshDevice.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/DigiPointDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/DigiPointDevice.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/Raw802Device.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/Raw802Device.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/ThreadDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/ThreadDevice.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/WiFiDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/WiFiDevice.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBee.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBee.java
@@ -18,8 +18,8 @@ package com.digi.xbee.api.android;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
-import com.digi.xbee.api.android.connection.AndroidXBeeInterface;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBInterface;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.android.connection.bluetooth.AndroidBluetoothInterface;
 import com.digi.xbee.api.android.connection.serial.SerialPortDigiAndroid;
 import com.digi.xbee.api.connection.IConnectionInterface;
@@ -71,7 +71,7 @@ public class XBee {
      * @see AndroidUSBPermissionListener
      */
     public static IConnectionInterface createConnectiontionInterface(Context context, int baudRate, AndroidUSBPermissionListener permissionListener) {
-        return new AndroidXBeeInterface(context, baudRate, permissionListener);
+        return new AndroidUSBInterface(context, baudRate, permissionListener);
     }
 
     /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBeeDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBeeDevice.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/ZigBeeDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/ZigBeeDevice.java
@@ -17,7 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.content.Context;
 
-import com.digi.xbee.api.android.connection.AndroidUSBPermissionListener;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
 
 /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInputStream.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInputStream.java
@@ -13,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF 
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package com.digi.xbee.api.android.connection;
+package com.digi.xbee.api.android.connection.usb;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,7 +50,7 @@ public class AndroidUSBInputStream extends InputStream {
 
 	private CircularByteBuffer readBuffer;
 
-	private AndroidXBeeInterface androidInterface;
+	private AndroidUSBInterface androidInterface;
 
 	private Logger logger;
 	
@@ -63,11 +63,11 @@ public class AndroidUSBInputStream extends InputStream {
 	 * @param readEndpoint The USB end point to use to read data from.
 	 * @param connection The USB connection to use to read data from.
 	 * 
-	 * @see AndroidXBeeInterface
+	 * @see AndroidUSBInterface
 	 * @see UsbDeviceConnection
 	 * @see UsbEndpoint
 	 */
-	public AndroidUSBInputStream(AndroidXBeeInterface androidInterface, UsbEndpoint readEndpoint, UsbDeviceConnection connection) {
+	public AndroidUSBInputStream(AndroidUSBInterface androidInterface, UsbEndpoint readEndpoint, UsbDeviceConnection connection) {
 		this.usbConnection = connection;
 		this.receiveEndPoint = readEndpoint;
 		this.androidInterface = androidInterface;

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInterface.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBInterface.java
@@ -13,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF 
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package com.digi.xbee.api.android.connection;
+package com.digi.xbee.api.android.connection.usb;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,17 +43,16 @@ import com.digi.xbee.api.exceptions.InvalidInterfaceException;
 import com.digi.xbee.api.exceptions.PermissionDeniedException;
 
 /**
- * This class represents a serial port using the RxTx library to communicate
- * with it.
+ * This class represents a communication interface with XBee devices over USB.
  */
-public class AndroidXBeeInterface implements IConnectionInterface {
+public class AndroidUSBInterface implements IConnectionInterface {
 
 	// Constants.
 	private static final int VID = 0x0403;
 	private static final int[] FTDI_PIDS = {
 			0x6001, // FT232 and FT245
 			//0x6010, // FT2232
-			//0x6011, // FT4232
+			0x6011, // FT4232
 			//0x6014, // FT232H
 			0x6015, // FT-X series
 			//0x601C, //FT4222H
@@ -94,7 +93,7 @@ public class AndroidXBeeInterface implements IConnectionInterface {
 	private Logger logger;
 
 	/**
-	 * Class constructor. Instantiates a new {@code AndroidXBeeInterface} object
+	 * Class constructor. Instantiates a new {@code AndroidUSBInterface} object
 	 * with the given parameters.
 	 * 
 	 * <p>This constructor requires that methods calling {@link #open()}
@@ -108,17 +107,17 @@ public class AndroidXBeeInterface implements IConnectionInterface {
 	 * @throws IllegalArgumentException if {@code baudRate < 1}.
 	 * @throws NullPointerException if {@code context == null}.
 	 * 
-	 * @see #AndroidXBeeInterface(Context, int)
-	 * @see #AndroidXBeeInterface(Context, int, AndroidUSBPermissionListener)
-	 * @see #AndroidXBeeInterface(Context, int, UsbDevice, AndroidUSBPermissionListener)
+	 * @see #AndroidUSBInterface(Context, int)
+	 * @see #AndroidUSBInterface(Context, int, AndroidUSBPermissionListener)
+	 * @see #AndroidUSBInterface(Context, int, UsbDevice, AndroidUSBPermissionListener)
 	 * @see UsbDevice
 	 */
-	public AndroidXBeeInterface(Context context, int baudRate, UsbDevice usbDevice) {
+	public AndroidUSBInterface(Context context, int baudRate, UsbDevice usbDevice) {
 		this(context, baudRate, usbDevice, null);
 	}
 
 	/**
-	 * Class constructor. Instantiates a new {@code AndroidXBeeInterface} object
+	 * Class constructor. Instantiates a new {@code AndroidUSBInterface} object
 	 * with the given parameters.
 	 * 
 	 * <p>This constructor requires all methods calling {@link #open()} 
@@ -131,16 +130,16 @@ public class AndroidXBeeInterface implements IConnectionInterface {
 	 * @throws IllegalArgumentException if {@code baudRate < 1}.
 	 * @throws NullPointerException if {@code context == null}.
 	 * 
-	 * @see #AndroidXBeeInterface(Context, int, AndroidUSBPermissionListener)
-	 * @see #AndroidXBeeInterface(Context, int, UsbDevice)
-	 * @see #AndroidXBeeInterface(Context, int, UsbDevice, AndroidUSBPermissionListener)
+	 * @see #AndroidUSBInterface(Context, int, AndroidUSBPermissionListener)
+	 * @see #AndroidUSBInterface(Context, int, UsbDevice)
+	 * @see #AndroidUSBInterface(Context, int, UsbDevice, AndroidUSBPermissionListener)
 	 */
-	public AndroidXBeeInterface(Context context, int baudRate) {
+	public AndroidUSBInterface(Context context, int baudRate) {
 		this(context, baudRate, null, null);
 	}
 
 	/**
-	 * Class constructor. Instantiates a new {@code AndroidXBeeInterface} object
+	 * Class constructor. Instantiates a new {@code AndroidUSBInterface} object
 	 * with the given parameters.
 	 * 
 	 * @param context The Android context.
@@ -152,17 +151,17 @@ public class AndroidXBeeInterface implements IConnectionInterface {
 	 * @throws IllegalArgumentException if {@code baudRate < 1}.
 	 * @throws NullPointerException if {@code context == null}.
 	 * 
-	 * @see #AndroidXBeeInterface(Context, int)
-	 * @see #AndroidXBeeInterface(Context, int, UsbDevice)
-	 * @see #AndroidXBeeInterface(Context, int, UsbDevice, AndroidUSBPermissionListener)
+	 * @see #AndroidUSBInterface(Context, int)
+	 * @see #AndroidUSBInterface(Context, int, UsbDevice)
+	 * @see #AndroidUSBInterface(Context, int, UsbDevice, AndroidUSBPermissionListener)
 	 * @see AndroidUSBPermissionListener
 	 */
-	public AndroidXBeeInterface(Context context, int baudRate, AndroidUSBPermissionListener permissionListener) {
+	public AndroidUSBInterface(Context context, int baudRate, AndroidUSBPermissionListener permissionListener) {
 		this(context, baudRate, null, permissionListener);
 	}
 	
 	/**
-	 * Class constructor. Instantiates a new {@code AndroidXBeeInterface} object
+	 * Class constructor. Instantiates a new {@code AndroidUSBInterface} object
 	 * with the given parameters.
 	 * 
 	 * @param context The Android context.
@@ -175,13 +174,13 @@ public class AndroidXBeeInterface implements IConnectionInterface {
 	 * @throws IllegalArgumentException if {@code baudRate < 1}.
 	 * @throws NullPointerException if {@code context == null}.
 	 * 
-	 * @see #AndroidXBeeInterface(Context, int)
-	 * @see #AndroidXBeeInterface(Context, int, AndroidUSBPermissionListener)
-	 * @see #AndroidXBeeInterface(Context, int, UsbDevice)
+	 * @see #AndroidUSBInterface(Context, int)
+	 * @see #AndroidUSBInterface(Context, int, AndroidUSBPermissionListener)
+	 * @see #AndroidUSBInterface(Context, int, UsbDevice)
 	 * @see AndroidUSBPermissionListener
 	 * @see UsbDevice
 	 */
-	public AndroidXBeeInterface(Context context, int baudRate, UsbDevice usbDevice, AndroidUSBPermissionListener permissionListener) {
+	public AndroidUSBInterface(Context context, int baudRate, UsbDevice usbDevice, AndroidUSBPermissionListener permissionListener) {
 		if (context == null)
 			throw new NullPointerException("Android context cannot be null.");
 		if (baudRate < 1)
@@ -192,7 +191,7 @@ public class AndroidXBeeInterface implements IConnectionInterface {
 		this.permissionListener = permissionListener;
 		this.usbDevice = usbDevice;
 		this.usbManager = (UsbManager)context.getSystemService(Context.USB_SERVICE);
-		this.logger = LoggerFactory.getLogger(AndroidXBeeInterface.class);
+		this.logger = LoggerFactory.getLogger(AndroidUSBInterface.class);
 	}
 
 	/**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBOutputStream.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBOutputStream.java
@@ -13,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF 
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package com.digi.xbee.api.android.connection;
+package com.digi.xbee.api.android.connection.usb;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBPermissionListener.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/AndroidUSBPermissionListener.java
@@ -13,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF 
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package com.digi.xbee.api.android.connection;
+package com.digi.xbee.api.android.connection.usb;
 
 /**
  * This interface is used as a listener to wait for user permissions after a 

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/CircularByteBuffer.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/connection/usb/CircularByteBuffer.java
@@ -13,7 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF 
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-package com.digi.xbee.api.android.connection;
+package com.digi.xbee.api.android.connection.usb;
 
 /**
  * Helper class used to store data bytes as a circular buffer.

--- a/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/AndroidUSBInputStreamTest.java
+++ b/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/AndroidUSBInputStreamTest.java
@@ -35,9 +35,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 
-import com.digi.xbee.api.android.connection.AndroidUSBInputStream;
-import com.digi.xbee.api.android.connection.AndroidXBeeInterface;
-import com.digi.xbee.api.android.connection.CircularByteBuffer;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBInputStream;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBInterface;
+import com.digi.xbee.api.android.connection.usb.CircularByteBuffer;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({System.class, AndroidUSBInputStream.class})
@@ -52,7 +52,7 @@ public class AndroidUSBInputStreamTest {
 	// Variables.
 	private UsbDeviceConnection usbConnection;
 	private UsbEndpoint receiveEndPoint;
-	private AndroidXBeeInterface androidInterface;
+	private AndroidUSBInterface androidInterface;
 
 	private CircularByteBuffer circularBuffer;
 
@@ -64,7 +64,7 @@ public class AndroidUSBInputStreamTest {
 		Mockito.when(usbConnection.bulkTransfer(Mockito.any(UsbEndpoint.class), Mockito.any(byte[].class),
 				Mockito.anyInt(), Mockito.anyInt())).thenReturn(DATA.length);
 		receiveEndPoint = Mockito.mock(UsbEndpoint.class);
-		androidInterface = Mockito.mock(AndroidXBeeInterface.class);
+		androidInterface = Mockito.mock(AndroidUSBInterface.class);
 
 		is = PowerMockito.spy(new AndroidUSBInputStream(androidInterface, receiveEndPoint, usbConnection));
 

--- a/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/AndroidUSBOutputStreamTest.java
+++ b/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/AndroidUSBOutputStreamTest.java
@@ -24,7 +24,7 @@ import org.powermock.api.mockito.PowerMockito;
 import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 
-import com.digi.xbee.api.android.connection.AndroidUSBOutputStream;
+import com.digi.xbee.api.android.connection.usb.AndroidUSBOutputStream;
 
 public class AndroidUSBOutputStreamTest {
 

--- a/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/CircularByteBufferCreateTest.java
+++ b/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/CircularByteBufferCreateTest.java
@@ -15,7 +15,7 @@
  */
 package com.digi.xbee.api.android.connection.android;
 
-import com.digi.xbee.api.android.connection.CircularByteBuffer;
+import com.digi.xbee.api.android.connection.usb.CircularByteBuffer;
 
 import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;

--- a/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/CircularByteBufferReadTest.java
+++ b/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/CircularByteBufferReadTest.java
@@ -15,7 +15,7 @@
  */
 package com.digi.xbee.api.android.connection.android;
 
-import com.digi.xbee.api.android.connection.CircularByteBuffer;
+import com.digi.xbee.api.android.connection.usb.CircularByteBuffer;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/CircularByteBufferWriteTest.java
+++ b/xbee_android_library/src/test/java/com/digi/xbee/api/android/connection/android/CircularByteBufferWriteTest.java
@@ -15,7 +15,7 @@
  */
 package com.digi.xbee.api.android.connection.android;
 
-import com.digi.xbee.api.android.connection.CircularByteBuffer;
+import com.digi.xbee.api.android.connection.usb.CircularByteBuffer;
 
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Rename also the 'AndroidXBeeInterface' class to 'AndroidUSBInterface'.

Signed-off-by: Ruben Moral <ruben.moral@digi.com>