### PR TITLE
Allow for explicit passing of Usb Device for XBeeDevice construction

### DIFF
--- a/examples/xbee_manager_sample/src/main/java/com/digi/xbee/sample/android/xbeemanager/managers/XBeeManager.java
+++ b/examples/xbee_manager_sample/src/main/java/com/digi/xbee/sample/android/xbeemanager/managers/XBeeManager.java
@@ -19,6 +19,7 @@ package com.digi.xbee.sample.android.xbeemanager.managers;
 import java.util.HashMap;
 
 import android.content.Context;
+import android.hardware.usb.UsbDevice;
 
 import com.digi.xbee.sample.android.xbeemanager.XBeeConstants;
 import com.digi.xbee.api.RemoteXBeeDevice;
@@ -66,6 +67,19 @@ public class XBeeManager {
 		this.baudRate = baudRate;
 		this.port = null;
 		localDevice = new XBeeDevice(context, baudRate);
+	}
+
+	/**
+	 * Creates the local XBee Device using the Android USB Host API with the
+	 * given baud rate and the specified UsbDevice handle.
+	 *
+	 * @param baudRate Baud rate to use in the XBee Connection.
+	 * @param usbDevice UsbDevice handle to use for the XBee connection.
+	 */
+	public void createXBeeDevice(int baudRate, UsbDevice usbDevice) {
+		this.baudRate = baudRate;
+		this.port = null;
+		localDevice = new XBeeDevice(context, baudRate, usbDevice);
 	}
 	
 	/**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBee.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBee.java
@@ -17,6 +17,7 @@ package com.digi.xbee.api.android;
 
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
+import android.hardware.usb.UsbDevice;
 
 import com.digi.xbee.api.android.connection.usb.AndroidUSBInterface;
 import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
@@ -56,6 +57,29 @@ public class XBee {
      * <p>This constructor uses the Android USB host interface API to
      * communicate with the devices.</p>
      *
+     * @param context The Android application context.
+     * @param baudRate The USB connection baud rate.
+     * @param usbDevice The explicit UsbDevice handle to use
+     *
+     * @return The XBee Android connection interface.
+     *
+     * @throws NullPointerException if {@code context == null}.
+     * @throws IllegalArgumentException if {@code baudRate < 1}.
+     *
+     * @see #createConnectiontionInterface(Context, int, AndroidUSBPermissionListener)
+     * @see com.digi.xbee.api.connection.IConnectionInterface
+     */
+    public static IConnectionInterface createConnectionInterface(Context context, int baudRate, UsbDevice usbDevice) {
+        return createConnectionInterface(context, baudRate, usbDevice, null);
+    }
+
+    /**
+     * Returns an XBee Android connection interface for the given context and
+     * baud rate.
+     *
+     * <p>This constructor uses the Android USB host interface API to
+     * communicate with the devices.</p>
+     *
      * @param context The Android context.
      * @param baudRate The USB connection baud rate.
      * @param permissionListener The USB permission listener that will be
@@ -72,6 +96,32 @@ public class XBee {
      */
     public static IConnectionInterface createConnectiontionInterface(Context context, int baudRate, AndroidUSBPermissionListener permissionListener) {
         return new AndroidUSBInterface(context, baudRate, permissionListener);
+    }
+
+    /**
+     * Returns an XBee Android connection interface for the given context and
+     * baud rate.
+     *
+     * <p>This constructor uses the Android USB host interface API to
+     * communicate with the devices.</p>
+     *
+     * @param context The Android context.
+     * @param baudRate The USB connection baud rate.
+     * @param usbDevice The explicit USBDevice handle to use
+     * @param permissionListener The USB permission listener that will be
+     *                           notified when user grants USB permissions.
+     *
+     * @return The XBee Android connection interface.
+     *
+     * @throws NullPointerException if {@code context == null}.
+     * @throws IllegalArgumentException if {@code baudRate < 1}.
+     *
+     * @see #createConnectiontionInterface(Context, int)
+     * @see com.digi.xbee.api.connection.IConnectionInterface
+     * @see AndroidUSBPermissionListener
+     */
+    public static IConnectionInterface createConnectionInterface(Context context, int baudRate, UsbDevice usbDevice, AndroidUSBPermissionListener permissionListener) {
+        return new AndroidUSBInterface(context, baudRate, usbDevice, permissionListener);
     }
 
     /**

--- a/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBeeDevice.java
+++ b/xbee_android_library/src/main/java/com/digi/xbee/api/android/XBeeDevice.java
@@ -16,6 +16,7 @@
 package com.digi.xbee.api.android;
 
 import android.content.Context;
+import android.hardware.usb.UsbDevice;
 
 import com.digi.xbee.api.android.connection.usb.AndroidUSBPermissionListener;
 import com.digi.xbee.api.connection.serial.SerialPortParameters;
@@ -62,6 +63,28 @@ public class XBeeDevice extends com.digi.xbee.api.XBeeDevice {
      *
      * @param context The Android context.
      * @param baudRate The USB connection baud rate.
+     * @param usbDevice The explicit UsbDevice handle to use
+     *
+     * @throws IllegalArgumentException if {@code baudRate < 1}.
+     * @throws NullPointerException if {@code context == null}.
+     *
+     * @see #XBeeDevice(Context, int, AndroidUSBPermissionListener)
+     * @see #XBeeDevice(Context, String, int)
+     * @see #XBeeDevice(Context, String, SerialPortParameters)
+     */
+    public XBeeDevice(Context context, int baudRate, UsbDevice usbDevice) {
+        super(XBee.createConnectionInterface(context, baudRate, usbDevice));
+    }
+
+    /**
+     * Class constructor. Instantiates a new {@code XBeeDevice} object for
+     * Android with the given parameters.
+     *
+     * <p>This constructor uses the Android USB host interface API to
+     * communicate with the devices.</p>
+     *
+     * @param context The Android context.
+     * @param baudRate The USB connection baud rate.
      * @param permissionListener The USB permission listener that will be
      *                           notified when user grants USB permissions.
      *
@@ -75,6 +98,31 @@ public class XBeeDevice extends com.digi.xbee.api.XBeeDevice {
      */
     public XBeeDevice(Context context, int baudRate, AndroidUSBPermissionListener permissionListener) {
         super(XBee.createConnectiontionInterface(context, baudRate, permissionListener));
+    }
+
+    /**
+     * Class constructor. Instantiates a new {@code XBeeDevice} object for
+     * Android with the given parameters.
+     *
+     * <p>This constructor uses the Android USB host interface API to
+     * communicate with the devices.</p>
+     *
+     * @param context The Android context.
+     * @param baudRate The USB connection baud rate.
+     * @param permissionListener The USB permission listener that will be
+     *                           notified when user grants USB permissions.
+     * @param usbDevice The explicit UsbDevice to use
+     *
+     * @throws IllegalArgumentException if {@code baudRate < 1}.
+     * @throws NullPointerException if {@code context == null}.
+     *
+     * @see #XBeeDevice(Context, int)
+     * @see #XBeeDevice(Context, String, int)
+     * @see #XBeeDevice(Context, String, SerialPortParameters)
+     * @see AndroidUSBPermissionListener
+     */
+    public XBeeDevice(Context context, int baudRate, UsbDevice usbDevice, AndroidUSBPermissionListener permissionListener) {
+        super(XBee.createConnectionInterface(context, baudRate, usbDevice, permissionListener));
     }
 
     /**


### PR DESCRIPTION
This allows for connecting to multiple connected XBeeDevices by enumerating Android USB DeviceList & then passing them explicitly to the XBeeDevice constructor.

Previously it was only possible to connect to the first found XBeeDevice which was implicitly queried in the AndroidUSBInterface. 

This fixes my issue here: #9 

PS: Should this pull request be fine it would make sense to update the XBeeManagerSample as well by displaying the connected device list from the USB Host just like with the SerialPort solution.